### PR TITLE
Adding Search Index Overlay

### DIFF
--- a/zune_ui/lib/pages/music_page/artist_list/artist_list.dart
+++ b/zune_ui/lib/pages/music_page/artist_list/artist_list.dart
@@ -1,5 +1,7 @@
 part of artist_list_widget;
 
+typedef ArtistGroupMap = LinkedHashMap<String, List<ArtistSummary>>;
+
 class ArtistList extends StatefulWidget {
   const ArtistList({
     super.key,
@@ -10,46 +12,78 @@ class ArtistList extends StatefulWidget {
 }
 
 class _ArtistListState extends State<ArtistList> {
+  /// NOTE: Artist List view allows "jumping" to a specific artist via
+  ///       group keys rendered in the list.
+  ///
+  ///       This method is responsible for generating search index configuration map
+  ///       which represents a group key e.g. letter "a" mapped to a function that
+  ///       animated scroll controller to a location of the group key in the list.
+  ///
+  ///       Using pre-defined constant values to derive the group collection & key heights
+  ///       because the list view wrapper is dynamically built. This might not be the best
+  ///       solution to derive the search index configuration, perhaps a global solution
+  ///       might be faster.
+  void _generateSearchIndexConfiguration(
+      ScrollController? scrollController, ArtistGroupMap artistGroupMap) {
+    // SearchIndexConfig is by default an empty map
+    if (scrollController == null) return;
+
+    double offset = 0.0;
+    SearchIndexConfig searchIndexConfiguration = {};
+
+    for (final entry in artistGroupMap.entries) {
+      // Since offset is a mutable closure, need to define a final value here
+      final currentOffset = offset;
+      searchIndexConfiguration.putIfAbsent(
+        entry.key,
+        () => () async => await scrollController.animateTo(
+              currentOffset,
+              duration: const Duration(milliseconds: 250),
+              curve: Curves.ease,
+            ),
+      );
+
+      // Derive group collection & key heights to compute offsets needed for animation
+      final groupCollectionHeight = entry.value.fold(offset,
+          (acc, artist) => acc + ARTIST_LIST_TILE_SIZE + ARTIST_LIST_GAP);
+      const groupKeyHeight = ARTIST_SEARCH_INDEX_TILE_SIZE + ARTIST_LIST_GAP;
+
+      offset = groupCollectionHeight + groupKeyHeight;
+    }
+
+    OverlaysProvider.of(context)?.setSearchTileConfig(searchIndexConfiguration);
+  }
+
+  /// NOTE: This method is responsible for generating artist groups which
+  ///       represent either a group key such as albums sorted under letter "a"
+  ///       OR the actual artist entry. Both are rendered by ArtistGroupTile.
+  ///
+  ///       There are two ways to generate group which specified in the utils:
+  ///       1. One shot method generateItemGroups which groups generateItemMap & generateItemListFromMap
+  ///       2. Use generateItemMap & generateItemListFromMap to fit search index configuration generation
   List<ArtistListTileGroup> _generateArtistGroups(
     List<ArtistSummary> artists, {
     ScrollController? scrollController,
   }) {
-    LinkedHashMap<String, List<ArtistSummary>> artistGroupMap =
-        parent.generateItemMap(
+    ArtistGroupMap artistGroupMap = parent.generateItemMap(
       artists,
       (e) => parent.generateItemGroupKey(e.artist_name),
     );
 
-    if (scrollController != null) {
-      /// NOTE: This provider exposes all of the overlays in the app.
-      final overlaysProvider = OverlaysProvider.of(context);
-      SearchIndexConfig searchIndexConfiguration = {};
-      double offset = 0.0;
-      for (final entry in artistGroupMap.entries) {
-        final currentOffset = offset;
-        console.log("Print me: $currentOffset ${entry.key}");
-        searchIndexConfiguration.putIfAbsent(
-          entry.key,
-          () => () async {
-            await scrollController.animateTo(
-              currentOffset,
-              duration: const Duration(milliseconds: 250),
-              curve: Curves.ease,
-            );
-          },
-        );
-        final collectionHeight =
-            entry.value.fold(offset, (acc, artist) => acc + 44 + 26);
-        const groupKeyHeight = 56 + 26;
-        offset = collectionHeight + groupKeyHeight;
-      }
+    _generateSearchIndexConfiguration(scrollController, artistGroupMap);
 
-      overlaysProvider?.setSearchTileConfig(searchIndexConfiguration);
-    }
     return parent.generateItemListFromMap(
       artistGroupMap,
       (groupKey, item) => (groupKey: groupKey, artist: item),
     );
+  }
+
+  @override
+  void deactivate() {
+    // Clear search tile config after the widget is deactivated
+    // Prevent case where config is present and used for incorrect widget
+    OverlaysProvider.of(context)?.setSearchTileConfig({});
+    super.deactivate();
   }
 
   @override

--- a/zune_ui/lib/pages/music_page/artist_list/artist_list.dart
+++ b/zune_ui/lib/pages/music_page/artist_list/artist_list.dart
@@ -11,12 +11,46 @@ class ArtistList extends StatefulWidget {
 
 class _ArtistListState extends State<ArtistList> {
   List<ArtistListTileGroup> _generateArtistGroups(
-          List<ArtistSummary> artists) =>
-      parent.generateItemGroups<ArtistSummary, ArtistListTileGroup>(
-        artists,
-        (groupKey, item) => (groupKey: groupKey, artist: item),
-        (e) => parent.generateItemGroupKey(e.artist_name),
-      );
+    List<ArtistSummary> artists, {
+    ScrollController? scrollController,
+  }) {
+    LinkedHashMap<String, List<ArtistSummary>> artistGroupMap =
+        parent.generateItemMap(
+      artists,
+      (e) => parent.generateItemGroupKey(e.artist_name),
+    );
+
+    if (scrollController != null) {
+      /// NOTE: This provider exposes all of the overlays in the app.
+      final overlaysProvider = OverlaysProvider.of(context);
+      SearchIndexConfig searchIndexConfiguration = {};
+      double offset = 0.0;
+      for (final entry in artistGroupMap.entries) {
+        final currentOffset = offset;
+        console.log("Print me: $currentOffset ${entry.key}");
+        searchIndexConfiguration.putIfAbsent(
+          entry.key,
+          () => () async {
+            await scrollController.animateTo(
+              currentOffset,
+              duration: const Duration(milliseconds: 250),
+              curve: Curves.ease,
+            );
+          },
+        );
+        final collectionHeight =
+            entry.value.fold(offset, (acc, artist) => acc + 44 + 26);
+        const groupKeyHeight = 56 + 26;
+        offset = collectionHeight + groupKeyHeight;
+      }
+
+      overlaysProvider?.setSearchTileConfig(searchIndexConfiguration);
+    }
+    return parent.generateItemListFromMap(
+      artistGroupMap,
+      (groupKey, item) => (groupKey: groupKey, artist: item),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +59,7 @@ class _ArtistListState extends State<ArtistList> {
       selector: (state) => state.allArtists,
       itemBuilder: (context, artistGroup) =>
           ArtistListTile(artistGroup: artistGroup),
-      itemsReducer: _generateArtistGroups,
+      itemsMiddleware: _generateArtistGroups,
     );
   }
 }

--- a/zune_ui/lib/pages/music_page/artist_list/artist_list_tile.dart
+++ b/zune_ui/lib/pages/music_page/artist_list/artist_list_tile.dart
@@ -2,42 +2,6 @@ part of artist_list_widget;
 
 typedef ArtistListTileGroup = ({String? groupKey, ArtistSummary? artist});
 
-final Map<int, ParallaxConfiguration> parallaxConfig = {
-  /// Play Button
-  0: (
-    x: 0,
-    y: 0,
-
-    /// NOTE: Fine tuned based on "vibes" as  close as I see on Zune display.
-    ///       Velocity is largest here to show the "shift" effect when scrolling.
-    ///       Signed direct is positive so that when scrolling down the play button
-    ///       moves down more apparently.
-    velocity: 1 * 8,
-    signedDirection: 1,
-  ),
-
-  /// Artist Title
-  1: (
-    x: 36.0 + 8.0,
-    y: 12,
-
-    /// NOTE: Lowering velocity here to accentuate play button & album row
-    ///       parallax effect.
-    ///       Signed direction is negative so that when scrolling down the title
-    ///       moves up making more space between title nad the album row.
-    velocity: 2 * 2,
-    signedDirection: -1,
-  ),
-
-  /// Albums Row
-  2: (
-    x: 36.0 + 8.0,
-    y: 32,
-    velocity: 3 * 4,
-    signedDirection: -1,
-  ),
-};
-
 class ArtistListTile extends StatelessWidget {
   final ArtistListTileGroup artistGroup;
 
@@ -63,11 +27,12 @@ class ArtistListTile extends StatelessWidget {
   Widget generateArtistTile(BuildContext context, ArtistSummary artist) {
     return ListItemWrapper<ArtistSummary>(
       data: artist,
+      height: ARTIST_LIST_TILE_SIZE,
       widgetConfigs: [
         // Play Button
         (
           builder: (context, artist) => const ListTilePlayButton(),
-          parallaxConfig: parallaxConfig[0]!
+          parallaxConfig: ARTIST_PARALLAX_CONFIG[0]!
         ),
         // Artist Tile
         (
@@ -76,13 +41,13 @@ class ArtistListTile extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 style: Styles.listTileFont,
               ),
-          parallaxConfig: parallaxConfig[1]!
+          parallaxConfig: ARTIST_PARALLAX_CONFIG[1]!
         ),
         // Artist Album Row
         (
           builder: (context, artist) =>
               LazyListTileAlbumRow(album_ids: artist.album_ids),
-          parallaxConfig: parallaxConfig[2]!
+          parallaxConfig: ARTIST_PARALLAX_CONFIG[2]!
         )
       ],
     );

--- a/zune_ui/lib/pages/music_page/artist_list/constants.dart
+++ b/zune_ui/lib/pages/music_page/artist_list/constants.dart
@@ -1,0 +1,41 @@
+part of artist_list_widget;
+
+const ARTIST_LIST_GAP = 26.0;
+const ARTIST_LIST_TILE_SIZE = 44.0;
+const ARTIST_SEARCH_INDEX_TILE_SIZE = TileUtility.smallTileWidth;
+
+const Map<int, ParallaxConfiguration> ARTIST_PARALLAX_CONFIG = {
+  /// Play Button
+  0: (
+    x: 0,
+    y: 0,
+
+    /// NOTE: Fine tuned based on "vibes" as  close as I see on Zune display.
+    ///       Velocity is largest here to show the "shift" effect when scrolling.
+    ///       Signed direct is positive so that when scrolling down the play button
+    ///       moves down more apparently.
+    velocity: 1 * 8,
+    signedDirection: 1,
+  ),
+
+  /// Artist Title
+  1: (
+    x: 36.0 + 8.0,
+    y: 12,
+
+    /// NOTE: Lowering velocity here to accentuate play button & album row
+    ///       parallax effect.
+    ///       Signed direction is negative so that when scrolling down the title
+    ///       moves up making more space between title nad the album row.
+    velocity: 2 * 2,
+    signedDirection: -1,
+  ),
+
+  /// Albums Row
+  2: (
+    x: 36.0 + 8.0,
+    y: 32,
+    velocity: 3 * 4,
+    signedDirection: -1,
+  ),
+};

--- a/zune_ui/lib/pages/music_page/artist_list/index.dart
+++ b/zune_ui/lib/pages/music_page/artist_list/index.dart
@@ -15,5 +15,6 @@ import 'package:zune_ui/pages/music_page/index.dart' as parent;
 
 part "artist_list.dart";
 part "artist_list_tile.dart";
+part "constants.dart";
 
 final console = parent.console;

--- a/zune_ui/lib/pages/music_page/artist_list/index.dart
+++ b/zune_ui/lib/pages/music_page/artist_list/index.dart
@@ -4,6 +4,8 @@ import 'dart:collection';
 
 import 'package:flutter/widgets.dart';
 import 'package:zune_ui/database/index.dart';
+import 'package:zune_ui/pages/search_index_page/index.dart'
+    show SearchIndexConfig;
 import 'package:zune_ui/widgets/common/index.dart';
 import 'package:zune_ui/pages/overlays_page/index.dart';
 import 'package:zune_ui/pages/music_page/common/index.dart';

--- a/zune_ui/lib/pages/music_page/common/list_wrapper.dart
+++ b/zune_ui/lib/pages/music_page/common/list_wrapper.dart
@@ -1,6 +1,6 @@
 part of music_common_widgets;
 
-const LIST_GAP = 26.0;
+const DEFAULT_LIST_GAP = 26.0;
 
 class ListWrapper<ItemList extends Iterable<Item>, Item, RenderItem>
     extends StatefulWidget {
@@ -15,7 +15,7 @@ class ListWrapper<ItemList extends Iterable<Item>, Item, RenderItem>
   const ListWrapper({
     super.key,
     this.itemsMiddleware,
-    this.listGap = LIST_GAP,
+    this.listGap = DEFAULT_LIST_GAP,
     required this.selector,
     required this.itemBuilder,
   });

--- a/zune_ui/lib/pages/music_page/common/list_wrapper.dart
+++ b/zune_ui/lib/pages/music_page/common/list_wrapper.dart
@@ -5,13 +5,16 @@ const LIST_GAP = 26.0;
 class ListWrapper<ItemList extends Iterable<Item>, Item, RenderItem>
     extends StatefulWidget {
   final double listGap;
-  final Iterable<RenderItem> Function(ItemList items)? itemsReducer;
+  final Iterable<RenderItem> Function(
+    ItemList items, {
+    ScrollController? scrollController,
+  })? itemsMiddleware;
   final ItemList Function(GlobalModalState state) selector;
   final Widget Function(BuildContext context, RenderItem item) itemBuilder;
 
   const ListWrapper({
     super.key,
-    this.itemsReducer,
+    this.itemsMiddleware,
     this.listGap = LIST_GAP,
     required this.selector,
     required this.itemBuilder,
@@ -33,31 +36,36 @@ class _ListWrapperState<ItemList extends Iterable<Item>, Item, RenderItem>
       ///       across the scroll container to return to the top/bottom
       ///       of the list.
       builder: (context, data, child) {
-        final items = widget.itemsReducer != null
-            ? widget.itemsReducer!(data)
-            : data as Iterable<RenderItem>;
-
-        if (items.isEmpty) return const EmptyCategory();
+        if (data.isEmpty) return const EmptyCategory();
 
         return OverScrollWrapper(
           /// NOTE: Using ListView separated her in order to configure
           ///       spaced out list item vertical view.
-          builder: (scrollController, scrollPhysics) => ListView.separated(
-            // Over-scroll logic props derived from OverScrollWrapper
-            controller: scrollController,
-            physics: scrollPhysics,
-            // Rest of ListView props:
-            scrollDirection: Axis.vertical,
-            padding: parent.CATEGORY_PADDING,
-            itemCount: items.length,
-            separatorBuilder: (context, index) => SizedBox(
-              height: widget.listGap,
-            ),
-            itemBuilder: (context, index) => widget.itemBuilder(
-              context,
-              items.elementAt(index),
-            ),
-          ),
+          builder: (scrollController, scrollPhysics) {
+            final items = widget.itemsMiddleware != null
+                ? widget.itemsMiddleware!(
+                    data,
+                    scrollController: scrollController,
+                  )
+                : data as Iterable<RenderItem>;
+
+            return ListView.separated(
+              // Over-scroll logic props derived from OverScrollWrapper
+              controller: scrollController,
+              physics: scrollPhysics,
+              // Rest of ListView props:
+              scrollDirection: Axis.vertical,
+              padding: parent.CATEGORY_PADDING,
+              itemCount: items.length,
+              separatorBuilder: (context, index) => SizedBox(
+                height: widget.listGap,
+              ),
+              itemBuilder: (context, index) => widget.itemBuilder(
+                context,
+                items.elementAt(index),
+              ),
+            );
+          },
         );
       },
     );

--- a/zune_ui/lib/pages/music_page/track_list/constants.dart
+++ b/zune_ui/lib/pages/music_page/track_list/constants.dart
@@ -1,0 +1,22 @@
+part of track_list_widget;
+
+const TRACK_LIST_GAP = 20.0;
+const TRACK_LIST_TILE_SIZE = 33.0;
+const TRACK_SEARCH_INDEX_TILE_SIZE = TileUtility.smallTileWidth;
+
+final Map<int, ParallaxConfiguration> TRACK_PARALLAX_CONFIG = {
+  // Track Title
+  0: (
+    x: 0,
+    y: 0,
+    velocity: 0,
+    signedDirection: 0,
+  ),
+  // Track Artist & Album Name
+  1: (
+    x: 0,
+    y: 20,
+    velocity: 0,
+    signedDirection: 0,
+  ),
+};

--- a/zune_ui/lib/pages/music_page/track_list/index.dart
+++ b/zune_ui/lib/pages/music_page/track_list/index.dart
@@ -6,6 +6,8 @@ import 'package:flutter/widgets.dart';
 import 'package:zune_ui/database/index.dart';
 import 'package:zune_ui/pages/music_page/common/index.dart';
 import 'package:zune_ui/pages/overlays_page/index.dart';
+import 'package:zune_ui/pages/search_index_page/index.dart'
+    show SearchIndexConfig;
 import 'package:zune_ui/widgets/common/index.dart';
 
 /// NOTE: Scoping imports behind parent, so that console log is exposed from Music Page
@@ -13,5 +15,6 @@ import 'package:zune_ui/pages/music_page/index.dart' as parent;
 
 part "track_list.dart";
 part "track_list_tile.dart";
+part "constants.dart";
 
 final console = parent.console;

--- a/zune_ui/lib/pages/music_page/track_list/track_list.dart
+++ b/zune_ui/lib/pages/music_page/track_list/track_list.dart
@@ -12,7 +12,10 @@ class TrackList extends StatefulWidget {
 }
 
 class _TrackListState extends State<TrackList> {
-  List<TrackListTileGroup> _generateTrackGroups(List<TrackSummary> tracks) =>
+  List<TrackListTileGroup> _generateTrackGroups(
+    List<TrackSummary> tracks, {
+    ScrollController? scrollController,
+  }) =>
       parent.generateItemGroups<TrackSummary, TrackListTileGroup>(
         tracks,
         (groupKey, item) => (groupKey: groupKey, track: item),
@@ -27,7 +30,7 @@ class _TrackListState extends State<TrackList> {
       selector: (state) => state.allTracks,
       itemBuilder: (context, trackGroup) =>
           TrackListTile(trackGroup: trackGroup),
-      itemsReducer: _generateTrackGroups,
+      itemsMiddleware: _generateTrackGroups,
     );
   }
 }

--- a/zune_ui/lib/pages/music_page/track_list/track_list.dart
+++ b/zune_ui/lib/pages/music_page/track_list/track_list.dart
@@ -1,6 +1,6 @@
 part of track_list_widget;
 
-const LIST_GAP = 20.0;
+typedef TrackGroupMap = LinkedHashMap<String, List<TrackSummary>>;
 
 class TrackList extends StatefulWidget {
   const TrackList({
@@ -12,21 +12,85 @@ class TrackList extends StatefulWidget {
 }
 
 class _TrackListState extends State<TrackList> {
-  List<TrackListTileGroup> _generateTrackGroups(
-    List<TrackSummary> tracks, {
-    ScrollController? scrollController,
-  }) =>
-      parent.generateItemGroups<TrackSummary, TrackListTileGroup>(
-        tracks,
-        (groupKey, item) => (groupKey: groupKey, track: item),
-        (e) => parent.generateItemGroupKey(e.track_name),
+  /// NOTE: Track List view allows "jumping" to a specific track via
+  ///       group keys rendered in the list.
+  ///
+  ///       This method is responsible for generating search index configuration map
+  ///       which represents a group key e.g. letter "a" mapped to a function that
+  ///       animated scroll controller to a location of the group key in the list.
+  ///
+  ///       Using pre-defined constant values to derive the group collection & key heights
+  ///       because the list view wrapper is dynamically built. This might not be the best
+  ///       solution to derive the search index configuration, perhaps a global solution
+  ///       might be faster.
+  void _generateSearchIndexConfiguration(
+      ScrollController? scrollController, TrackGroupMap trackGroupMap) {
+    // SearchIndexConfig is by default an empty map
+    if (scrollController == null) return;
+
+    double offset = 0.0;
+    SearchIndexConfig searchIndexConfiguration = {};
+
+    for (final entry in trackGroupMap.entries) {
+      // Since offset is a mutable closure, need to define a final value here
+      final currentOffset = offset;
+      searchIndexConfiguration.putIfAbsent(
+        entry.key,
+        () => () async => await scrollController.animateTo(
+              currentOffset,
+              duration: const Duration(milliseconds: 250),
+              curve: Curves.ease,
+            ),
       );
+
+      // Derive group collection & key heights to compute offsets needed for animation
+      final groupCollectionHeight = entry.value.fold(
+          offset, (acc, artist) => acc + TRACK_LIST_TILE_SIZE + TRACK_LIST_GAP);
+      const groupKeyHeight = TRACK_SEARCH_INDEX_TILE_SIZE + TRACK_LIST_GAP;
+
+      offset = groupCollectionHeight + groupKeyHeight;
+    }
+
+    OverlaysProvider.of(context)?.setSearchTileConfig(searchIndexConfiguration);
+  }
+
+  /// NOTE: This method is responsible for generating track groups which
+  ///       represent either a group key such as albums sorted under letter "a"
+  ///       OR the actual track entry. Both are rendered by TrackGroupTile.
+  ///
+  ///       There are two ways to generate group which specified in the utils:
+  ///       1. One shot method generateItemGroups which groups generateItemMap & generateItemListFromMap
+  ///       2. Use generateItemMap & generateItemListFromMap to fit search index configuration generation
+  List<TrackListTileGroup> _generateTrackGroups(
+    List<TrackSummary> artists, {
+    ScrollController? scrollController,
+  }) {
+    TrackGroupMap trackGroupMap = parent.generateItemMap(
+      artists,
+      (e) => parent.generateItemGroupKey(e.track_name),
+    );
+
+    _generateSearchIndexConfiguration(scrollController, trackGroupMap);
+
+    return parent.generateItemListFromMap(
+      trackGroupMap,
+      (groupKey, item) => (groupKey: groupKey, track: item),
+    );
+  }
+
+  @override
+  void deactivate() {
+    // Clear search tile config after the widget is deactivated
+    // Prevent case where config is present and used for incorrect widget
+    OverlaysProvider.of(context)?.setSearchTileConfig({});
+    super.deactivate();
+  }
 
   @override
   Widget build(BuildContext context) {
     return ListWrapper<UnmodifiableListView<TrackSummary>, TrackSummary,
         TrackListTileGroup>(
-      listGap: LIST_GAP,
+      listGap: TRACK_LIST_GAP,
       selector: (state) => state.allTracks,
       itemBuilder: (context, trackGroup) =>
           TrackListTile(trackGroup: trackGroup),

--- a/zune_ui/lib/pages/music_page/track_list/track_list_tile.dart
+++ b/zune_ui/lib/pages/music_page/track_list/track_list_tile.dart
@@ -2,23 +2,6 @@ part of track_list_widget;
 
 typedef TrackListTileGroup = ({String? groupKey, TrackSummary? track});
 
-final Map<int, ParallaxConfiguration> parallaxConfig = {
-  // Track Title
-  0: (
-    x: 0,
-    y: 0,
-    velocity: 0,
-    signedDirection: 0,
-  ),
-  // Track Artist & Album Name
-  1: (
-    x: 0,
-    y: 20,
-    velocity: 0,
-    signedDirection: 0,
-  ),
-};
-
 class TrackListTile extends StatelessWidget {
   final TrackListTileGroup trackGroup;
 
@@ -44,7 +27,7 @@ class TrackListTile extends StatelessWidget {
   Widget generateTrackTile(BuildContext context, TrackSummary track) {
     return ListItemWrapper<TrackSummary>(
       data: track,
-      height: 32.0,
+      height: TRACK_LIST_TILE_SIZE,
       widgetConfigs: [
         // Track Title
         (
@@ -56,7 +39,7 @@ class TrackListTile extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                 ),
               ),
-          parallaxConfig: parallaxConfig[0]!
+          parallaxConfig: TRACK_PARALLAX_CONFIG[0]!
         ),
         // Track Artist & Album Name
         (
@@ -66,7 +49,7 @@ class TrackListTile extends StatelessWidget {
                 overflow: TextOverflow.visible,
                 style: Styles.listSubtileFont,
               ),
-          parallaxConfig: parallaxConfig[1]!
+          parallaxConfig: TRACK_PARALLAX_CONFIG[1]!
         ),
       ],
     );

--- a/zune_ui/lib/pages/music_page/utils.dart
+++ b/zune_ui/lib/pages/music_page/utils.dart
@@ -45,18 +45,12 @@ String generateItemGroupKey(String itemName) {
   return groupKey;
 }
 
-/// NOTE: Method responsible for generating item alphabetical groups based on a string key.
-///       List<Item> items - List of items e.g. albums/genres
-///       ItemGroup Function(String? groupKey, Item? item) groupBuilder - Tuple group generator
-///        String Function(Item item) groupKeyGenerator - Group key generator
-List<ItemGroup> generateItemGroups<Item, ItemGroup>(
+LinkedHashMap<String, List<Item>> generateItemMap<Item>(
   List<Item> items,
-  ItemGroup Function(String? groupKey, Item? item) groupBuilder,
   String Function(Item item) groupKeyGenerator,
 ) {
-  if (items.isEmpty) return [];
-
   final LinkedHashMap<String, List<Item>> map = LinkedHashMap();
+  if (items.isEmpty) return map;
 
   // "#" group key goes first and represents items starting with a number
   map.putIfAbsent("#", () => []);
@@ -75,6 +69,15 @@ List<ItemGroup> generateItemGroups<Item, ItemGroup>(
   // TODO: Might not be actually correctly implemented...
   map.putIfAbsent(".", () => []);
 
+  return map;
+}
+
+List<ItemGroup> generateItemListFromMap<Item, ItemGroup>(
+  LinkedHashMap<String, List<Item>> map,
+  ItemGroup Function(String? groupKey, Item? item) groupBuilder,
+) {
+  if (map.isEmpty) return [];
+
   // Reduce the map to a Item Group where first entry is a group key configuration
   // and the rest in a group are the items under said group
   // e.g. all albums starting with letter "a"
@@ -92,4 +95,19 @@ List<ItemGroup> generateItemGroups<Item, ItemGroup>(
     }
   }
   return result;
+}
+
+/// NOTE: Method responsible for generating item alphabetical groups based on a string key.
+///       List<Item> items - List of items e.g. albums/genres
+///       ItemGroup Function(String? groupKey, Item? item) groupBuilder - Tuple group generator
+///        String Function(Item item) groupKeyGenerator - Group key generator
+List<ItemGroup> generateItemGroups<Item, ItemGroup>(
+  List<Item> items,
+  ItemGroup Function(String? groupKey, Item? item) groupBuilder,
+  String Function(Item item) groupKeyGenerator,
+) {
+  final LinkedHashMap<String, List<Item>> map =
+      generateItemMap(items, groupKeyGenerator);
+
+  return generateItemListFromMap(map, groupBuilder);
 }

--- a/zune_ui/lib/pages/overlays_page/page.dart
+++ b/zune_ui/lib/pages/overlays_page/page.dart
@@ -25,6 +25,8 @@ class _OverlaysPageState extends State<OverlaysPage>
   final OverlayPortalController _searchIndexPageOverlayController =
       OverlayPortalController();
 
+  SearchIndexConfig _searchIndexConfig = {};
+
   @override
   void initState() {
     super.initState();
@@ -88,10 +90,15 @@ class _OverlaysPageState extends State<OverlaysPage>
     }
   }
 
+  void _setSearchTileConfig(SearchIndexConfig configuration) {
+    _searchIndexConfig = configuration;
+  }
+
   @override
   Widget build(BuildContext context) {
     return OverlaysProvider(
       showOverlay: _showOverlay,
+      setSearchTileConfig: _setSearchTileConfig,
       child: Stack(
         children: [
           OverlayPortal(
@@ -99,6 +106,7 @@ class _OverlaysPageState extends State<OverlaysPage>
             overlayChildBuilder: (context) => SearchIndexPage(
               closeOverlayHandler: _closeSearchIndexPageOverlay,
               parentController: _searchIndexPagAnimationController,
+              configuration: _searchIndexConfig,
             ),
           ),
           OverlayPortal(

--- a/zune_ui/lib/pages/overlays_page/page.dart
+++ b/zune_ui/lib/pages/overlays_page/page.dart
@@ -37,7 +37,7 @@ class _OverlaysPageState extends State<OverlaysPage>
     );
     _searchIndexPagAnimationController = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 500),
+      duration: const Duration(milliseconds: 250),
     );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/zune_ui/lib/pages/overlays_page/wrapper.dart
+++ b/zune_ui/lib/pages/overlays_page/wrapper.dart
@@ -8,10 +8,12 @@ enum OverlayType {
 
 class OverlaysProvider extends InheritedWidget {
   final void Function(OverlayType type) showOverlay;
+  final void Function(SearchIndexConfig configuration) setSearchTileConfig;
 
   const OverlaysProvider({
     Key? key,
     required this.showOverlay,
+    required this.setSearchTileConfig,
     required Widget child,
   }) : super(key: key, child: child);
 

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -23,8 +23,8 @@ class _SearchIndexPageState extends State<SearchIndexPage>
     with SingleTickerProviderStateMixin {
   late final Animation<double> _slideOutYOffsetAnimation;
   final Debouncer _autoCloseDebouncer = Debouncer(
-    duration: const Duration(seconds: 2),
-    debugName: "auto-close-effect",
+    duration: const Duration(seconds: 5),
+    debugName: "search-index-auto-close-effect",
     logger: console,
   );
 
@@ -33,8 +33,6 @@ class _SearchIndexPageState extends State<SearchIndexPage>
   @override
   void initState() {
     super.initState();
-
-    // console.log("render me");
 
     _slideOutYOffsetAnimation = TweenSequence<double>([
       TweenSequenceItem(
@@ -52,36 +50,44 @@ class _SearchIndexPageState extends State<SearchIndexPage>
     _triggerInitialAnimation();
   }
 
-  void _triggerInitialAnimation() {
-    // widget.parentController.animateTo(0.5).then(
-    //       (_) => _triggerDebouncer(),
-    //     );
-    widget.parentController.animateTo(0.5);
+  @override
+  void dispose() {
+    _autoCloseDebouncer.cancel();
+    super.dispose();
   }
 
-  void _animateAutoClose() {
-    // Start animation
-    widget.parentController.forward(from: 0.5).then((_) {
-      widget.closeOverlayHandler();
-      // setState(() {
-      //   // widget.parentController.reset();
-      //   // _panelIsInUse = false;
-      // });
-    });
-  }
+  void _triggerInitialAnimation() =>
+      widget.parentController.animateTo(0.5).then(
+            (_) => _animateAutoClose(),
+          );
 
-  void _triggerDebouncer() {
-    /// NOTE: Abstraction to trigger bounce animation delayed by the debouncer
-    _autoCloseDebouncer.call(() => _animateAutoClose());
-  }
-
-  void onSearchIndexTileTapHandler(String groupKey) {
-    if (widget.configuration.containsKey(groupKey)) {
-      final action = widget.configuration[groupKey]!;
-      _animateAutoClose();
-      action();
+  void _animateAutoClose({bool forceAnimate = false}) {
+    // AutoClose animation dispatch callback
+    dispatch() => widget.parentController
+        .forward(from: 0.5)
+        .then((_) => widget.closeOverlayHandler());
+    // Skip debounce
+    if (forceAnimate) {
+      dispatch();
+    } else {
+      _autoCloseDebouncer.call(dispatch);
     }
   }
+
+  /// NOTE: This method is responsible for executing the animate to
+  ///       callback if the groupKey is present in the configuration
+  ///       dictionary. If present, force execute the auto close animation
+  ///       and execute the callback.
+  void _onSearchIndexTileTapHandler(String groupKey) {
+    if (widget.configuration.containsKey(groupKey)) {
+      _animateAutoClose(forceAnimate: true);
+      widget.configuration[groupKey]!();
+    }
+  }
+
+  /// NOTE: Capture taps which do not result into scroll animation
+  ///       and debounce the auto close animation.
+  void _handleUnrelatedTap() => _animateAutoClose();
 
   @override
   Widget build(BuildContext context) {
@@ -92,6 +98,7 @@ class _SearchIndexPageState extends State<SearchIndexPage>
       builder: (context, child) => Transform.translate(
         offset: Offset(0, _slideOutYOffsetAnimation.value),
         child: GestureDetector(
+          onTap: _handleUnrelatedTap,
           child: Container(
             padding: const EdgeInsets.only(top: 8),
             color: Colors.black.withAlpha(250),
@@ -113,7 +120,8 @@ class _SearchIndexPageState extends State<SearchIndexPage>
                       index: indexKey[index],
                       isDisabled:
                           !widget.configuration.containsKey(indexKey[index]),
-                      onTap: () => onSearchIndexTileTapHandler(indexKey[index]),
+                      onTap: () =>
+                          _onSearchIndexTileTapHandler(indexKey[index]),
                     ),
             ),
           ),

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -28,8 +28,6 @@ class _SearchIndexPageState extends State<SearchIndexPage>
     logger: console,
   );
 
-  // bool _panelIsInUse = false;
-
   @override
   void initState() {
     super.initState();

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -111,6 +111,8 @@ class _SearchIndexPageState extends State<SearchIndexPage>
                     )
                   : SearchIndexTile(
                       index: indexKey[index],
+                      isDisabled:
+                          !widget.configuration.containsKey(indexKey[index]),
                       onTap: () => onSearchIndexTileTapHandler(indexKey[index]),
                     ),
             ),

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -89,6 +89,10 @@ class _SearchIndexPageState extends State<SearchIndexPage>
   ///       and debounce the auto close animation.
   void _handleUnrelatedTap() => _animateAutoClose();
 
+  /// NOTE: This method is responsible for closing the search index page
+  ///       via force animation.
+  void _handleExitTap() => _animateAutoClose(forceAnimate: true);
+
   @override
   Widget build(BuildContext context) {
     const indexKey = " #abcdefghijklmnopqrstuvwxyz";
@@ -112,9 +116,12 @@ class _SearchIndexPageState extends State<SearchIndexPage>
               ),
               itemCount: indexKey.length,
               itemBuilder: (context, index) => index == 0
-                  ? Text(
-                      "exit".toUpperCase(),
-                      style: Styles.exitLabel,
+                  ? GestureDetector(
+                      onTap: _handleExitTap,
+                      child: Text(
+                        "exit".toUpperCase(),
+                        style: Styles.exitLabel,
+                      ),
                     )
                   : SearchIndexTile(
                       index: indexKey[index],

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -1,13 +1,18 @@
 part of search_index_page;
 
+typedef SearchIndexConfig = Map<String, Future<void> Function()>;
+
 class SearchIndexPage extends StatefulWidget {
   final AnimationController parentController;
   final void Function() closeOverlayHandler;
+
+  final SearchIndexConfig configuration;
 
   const SearchIndexPage({
     super.key,
     required this.closeOverlayHandler,
     required this.parentController,
+    required this.configuration,
   });
 
   @override
@@ -57,7 +62,7 @@ class _SearchIndexPageState extends State<SearchIndexPage>
   void _animateAutoClose() {
     // Start animation
     widget.parentController.forward(from: 0.5).then((_) {
-      widget.parentController.reset();
+      widget.closeOverlayHandler();
       // setState(() {
       //   // widget.parentController.reset();
       //   // _panelIsInUse = false;
@@ -68,6 +73,14 @@ class _SearchIndexPageState extends State<SearchIndexPage>
   void _triggerDebouncer() {
     /// NOTE: Abstraction to trigger bounce animation delayed by the debouncer
     _autoCloseDebouncer.call(() => _animateAutoClose());
+  }
+
+  void onSearchIndexTileTapHandler(String groupKey) {
+    if (widget.configuration.containsKey(groupKey)) {
+      final action = widget.configuration[groupKey]!;
+      _animateAutoClose();
+      action();
+    }
   }
 
   @override
@@ -98,7 +111,7 @@ class _SearchIndexPageState extends State<SearchIndexPage>
                     )
                   : SearchIndexTile(
                       index: indexKey[index],
-                      onTap: () {},
+                      onTap: () => onSearchIndexTileTapHandler(indexKey[index]),
                     ),
             ),
           ),

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -48,9 +48,10 @@ class _SearchIndexPageState extends State<SearchIndexPage>
   }
 
   void _triggerInitialAnimation() {
-    widget.parentController.animateTo(0.5).then(
-          (_) => _triggerDebouncer(),
-        );
+    // widget.parentController.animateTo(0.5).then(
+    //       (_) => _triggerDebouncer(),
+    //     );
+    widget.parentController.animateTo(0.5);
   }
 
   void _animateAutoClose() {
@@ -71,7 +72,7 @@ class _SearchIndexPageState extends State<SearchIndexPage>
 
   @override
   Widget build(BuildContext context) {
-    const indexKey = "#abcdefghijklmnoprstuvwxyz.";
+    const indexKey = " #abcdefghijklmnoprstuvwxyz.";
 
     return AnimatedBuilder(
       animation: _slideOutYOffsetAnimation,
@@ -79,37 +80,26 @@ class _SearchIndexPageState extends State<SearchIndexPage>
         offset: Offset(0, _slideOutYOffsetAnimation.value),
         child: GestureDetector(
           child: Container(
+            padding: const EdgeInsets.only(top: 8),
             color: Colors.black.withAlpha(250),
-            // padding: const EdgeInsets.only(
-            //     left: 12.0, right: 12.0, bottom: 12.0, top: 12),
-            child: Wrap(
-              spacing: 8.0,
-              runSpacing: 8.0,
-              children: [
-                GestureDetector(
-                  // Account for container's padding when doing test detection
-                  behavior: HitTestBehavior.translucent,
-                  // onTap: () => widget.closeOverlayHandler(fastClose: true),
-                  child: Container(
-                    padding: const EdgeInsets.all(8),
-                    width: 56,
-                    height: 56,
-                    child: Text(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 4,
+                crossAxisSpacing: 8.0,
+                mainAxisSpacing: 8.0,
+                childAspectRatio: 1,
+              ),
+              itemCount: indexKey.length,
+              itemBuilder: (context, index) => index == 0
+                  ? Text(
                       "exit".toUpperCase(),
                       style: Styles.exitLabel,
-                    ),
-                  ),
-                ),
-                ...indexKey
-                    .split("")
-                    .map(
-                      (index) => SearchIndexTile(
-                        index: index,
-                        onTap: () {},
-                      ),
                     )
-                    .toList(),
-              ],
+                  : SearchIndexTile(
+                      index: indexKey[index],
+                      onTap: () {},
+                    ),
             ),
           ),
         ),

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -85,7 +85,7 @@ class _SearchIndexPageState extends State<SearchIndexPage>
 
   @override
   Widget build(BuildContext context) {
-    const indexKey = " #abcdefghijklmnoprstuvwxyz.";
+    const indexKey = " #abcdefghijklmnopqrstuvwxyz";
 
     return AnimatedBuilder(
       animation: _slideOutYOffsetAnimation,

--- a/zune_ui/lib/pages/search_index_page/page.dart
+++ b/zune_ui/lib/pages/search_index_page/page.dart
@@ -42,7 +42,7 @@ class _SearchIndexPageState extends State<SearchIndexPage>
       ),
       TweenSequenceItem(
         tween: Tween<double>(begin: 0, end: -480)
-            .chain(CurveTween(curve: Curves.bounceOut)),
+            .chain(CurveTween(curve: Curves.easeOut)),
         weight: 1,
       ),
     ]).animate(widget.parentController);

--- a/zune_ui/lib/widgets/common/album_tile.dart
+++ b/zune_ui/lib/widgets/common/album_tile.dart
@@ -91,23 +91,31 @@ class TrackTile extends StatelessWidget {
 
 class SearchIndexTile extends StatelessWidget {
   final String index;
+  final bool isDisabled;
   final void Function() onTap;
 
   const SearchIndexTile({
     super.key,
+    this.isDisabled = false,
     required this.index,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: SquareTile(
-        size: TileUtility.smallTileWidth,
-        alignment: Alignment.bottomRight,
-        textStyle: TextStyles.searchIndexTile,
-        text: index,
+    return Opacity(
+      opacity: isDisabled ? 0.5 : 1.0,
+      child: IgnorePointer(
+        ignoring: isDisabled,
+        child: GestureDetector(
+          onTap: onTap,
+          child: SquareTile(
+            size: TileUtility.smallTileWidth,
+            alignment: Alignment.bottomRight,
+            textStyle: TextStyles.searchIndexTile,
+            text: index,
+          ),
+        ),
       ),
     );
   }
@@ -158,7 +166,7 @@ class SquareTile extends StatelessWidget {
                   ? null
                   : Border.all(
                       width: 1,
-                      color: Colors.white.withAlpha(50),
+                      color: Colors.white.withAlpha(75),
                     ),
             )
           : null,

--- a/zune_ui/lib/widgets/over_scroll_wrapper/over_scroll_wrapper.dart
+++ b/zune_ui/lib/widgets/over_scroll_wrapper/over_scroll_wrapper.dart
@@ -1,6 +1,10 @@
 part of over_scroll_wrapper;
 
-const OVERSCROLL_THRESHOLD = 84;
+/// TODO:
+///       Changing 84 to 168 threshold to prevent overscroll trigger
+///       during the search index animation to latter letter causing
+///       wrong positions.
+const OVERSCROLL_THRESHOLD = 168;
 
 class OverScrollWrapper extends StatefulWidget {
   final Widget Function(


### PR DESCRIPTION
**Description:**
Adding changes needed to support Search Index Overlay which is used to "jump to" alphabetical groups of artist/tracks/albums.

**Changes:**
- Refactored Search Index Overlay to request SearchIndexConfiguration typed config which will map avaiable groups to a callback which will "jump to" item using scroll controller's animate to callback.
- Refactored generateItemGroups in music utils into separate helpers generateItemMap & generateItemListFromMap which help generate search index configuration when supported view is opened.
- Refactored Artist/Track Views to support Search Index Overlay for jumping to specific tracks/artists. (Future support for albums will be done as part of a separate Album List View PR)